### PR TITLE
Add missing routes and strengthen error handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,8 @@ import Home from "@/pages/home";
 import EvidenceManagement from "@/pages/evidence-management";
 import NotionSync from "@/pages/notion-sync";
 import NotFound from "@/pages/not-found";
+import Search from "@/pages/search";
+import Chain from "@/pages/chain";
 
 function Router() {
   return (
@@ -16,6 +18,8 @@ function Router() {
       <Route path="/" component={Home} />
       <Route path="/evidence" component={EvidenceManagement} />
       <Route path="/notion" component={NotionSync} />
+      <Route path="/search" component={Search} />
+      <Route path="/chain" component={Chain} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -104,15 +104,15 @@ export default function HeroSection() {
                 
                 <div className="grid grid-cols-3 gap-4 text-center">
                   <div className="bg-slate-700/30 rounded-lg p-3">
-                    <div className="text-emerald-400 font-bold text-lg">{stats?.evidenceArtifacts || '2,847'}</div>
+                    <div className="text-emerald-400 font-bold text-lg">{stats?.evidenceArtifacts ?? '2,847'}</div>
                     <div className="text-slate-400 text-xs">Evidence Items</div>
                   </div>
                   <div className="bg-slate-700/30 rounded-lg p-3">
-                    <div className="text-blue-400 font-bold text-lg">{stats?.verificationRate || '99.7'}%</div>
+                    <div className="text-blue-400 font-bold text-lg">{stats?.verificationRate ?? '99.7'}%</div>
                     <div className="text-slate-400 text-xs">Trust Score</div>
                   </div>
                   <div className="bg-slate-700/30 rounded-lg p-3">
-                    <div className="text-cyan-400 font-bold text-lg">{stats?.activeCases || '45'}</div>
+                    <div className="text-cyan-400 font-bold text-lg">{stats?.activeCases ?? '45'}</div>
                     <div className="text-slate-400 text-xs">Active Cases</div>
                   </div>
                 </div>

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "wouter";
-import { Scale, Home, FileText, Search, Link as LinkIcon, Database, Zap } from "lucide-react";
+import { Scale, Home, FileText, Search, Link as LinkIcon, Database } from "lucide-react";
 
 export default function Navigation() {
   const [location] = useLocation();

--- a/client/src/pages/chain.tsx
+++ b/client/src/pages/chain.tsx
@@ -1,0 +1,150 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ShieldCheck, Link as LinkIcon } from "lucide-react";
+import TrustTimeline from "@/components/trust-timeline";
+import MintingEligibility from "@/components/minting-eligibility";
+import ErrorBoundary from "@/components/error-boundary";
+import type { Evidence, ChainOfCustody } from "@shared/schema";
+
+export default function Chain() {
+  const { data: evidence, isLoading, error } = useQuery<Evidence[]>({
+    queryKey: ["/api/evidence"],
+  });
+
+  const activeEvidence = useMemo(() => {
+    if (!Array.isArray(evidence) || evidence.length === 0) {
+      return null;
+    }
+
+    return evidence.find((item) => item.status === "MINTED") ?? evidence[0];
+  }, [evidence]);
+
+  const timelineEvidence = useMemo(() => {
+    if (!activeEvidence) {
+      return null;
+    }
+
+    const toIsoString = (value: Date | string | null | undefined) => {
+      if (!value) return null;
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+    };
+
+    return {
+      originalTrustScore: activeEvidence.originalTrustScore ?? "0.00",
+      trustScore: activeEvidence.trustScore ?? "0.00",
+      status: activeEvidence.status ?? "PENDING",
+      verifiedAt: toIsoString(activeEvidence.verifiedAt),
+      mintedAt: toIsoString(activeEvidence.mintedAt),
+      uploadedAt: toIsoString(activeEvidence.uploadedAt) ?? new Date().toISOString(),
+    };
+  }, [activeEvidence]);
+
+  const { data: custodyEntries = [] } = useQuery<ChainOfCustody[]>({
+    queryKey: activeEvidence ? [`/api/evidence/${activeEvidence.id}/custody`] : ["chain/empty"],
+    enabled: Boolean(activeEvidence),
+  });
+
+  return (
+    <section className="py-24 bg-slate-950 min-h-screen">
+      <div className="container mx-auto px-8 space-y-12">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-4xl font-bold text-slate-50 mb-3">Chain of Custody</h2>
+            <p className="text-slate-400 max-w-2xl">
+              Monitor ledger-qualified evidence as it progresses from verification to permanent ChittyChain storage.
+            </p>
+          </div>
+          <Badge className="bg-emerald-400/20 text-emerald-300 border-emerald-400/40 uppercase tracking-wide">
+            Real-time ledger feed
+          </Badge>
+        </div>
+
+        {error && (
+          <Alert className="bg-red-900/20 border-red-500/40 text-red-200">
+            <AlertDescription>
+              Unable to load chain of custody data. Please refresh the page to try again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {isLoading && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="h-80 rounded-2xl bg-slate-900/70 border border-slate-800 animate-pulse" />
+            <div className="h-80 rounded-2xl bg-slate-900/70 border border-slate-800 animate-pulse" />
+          </div>
+        )}
+
+        {!isLoading && !activeEvidence && (
+          <Card className="bg-slate-900/70 border-slate-800">
+            <CardHeader>
+              <CardTitle className="text-slate-100 text-xl">No evidence available</CardTitle>
+              <CardDescription className="text-slate-400">
+                Upload evidence to begin tracking the immutable chain of custody lifecycle.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+
+        {activeEvidence && timelineEvidence && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <ErrorBoundary>
+              <TrustTimeline evidence={timelineEvidence} />
+            </ErrorBoundary>
+            <ErrorBoundary>
+              <MintingEligibility evidenceId={activeEvidence.id} />
+            </ErrorBoundary>
+          </div>
+        )}
+
+        {activeEvidence && (
+          <Card className="bg-slate-900/70 border-slate-800">
+            <CardHeader className="flex flex-row items-start justify-between">
+              <div>
+                <CardTitle className="text-slate-100 text-2xl flex items-center">
+                  <ShieldCheck className="w-5 h-5 mr-2 text-emerald-300" />
+                  Ledger Events
+                </CardTitle>
+                <CardDescription className="text-slate-400">
+                  Custody trail for <span className="font-medium text-slate-200">{activeEvidence.filename}</span>
+                </CardDescription>
+              </div>
+              <Badge className="bg-slate-800 text-slate-300 border-slate-700">{custodyEntries.length} events</Badge>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6">
+                {custodyEntries.map((entry) => (
+                  <div key={entry.id} className="flex items-start justify-between border-b border-slate-800 pb-4 last:border-b-0 last:pb-0">
+                    <div>
+                      <div className="flex items-center text-slate-200">
+                        <LinkIcon className="w-4 h-4 mr-2 text-emerald-300" />
+                        {entry.action}
+                      </div>
+                      {entry.notes && <p className="text-sm text-slate-400 mt-1">{entry.notes}</p>}
+                    </div>
+                    <div className="text-right text-sm text-slate-400">
+                      <div>{new Date(entry.timestamp).toLocaleString()}</div>
+                      {entry.location && <div className="text-slate-500">{entry.location}</div>}
+                    </div>
+                  </div>
+                ))}
+
+                {custodyEntries.length === 0 && (
+                  <p className="text-slate-400">
+                    No custody events recorded yet. Verification or minting activity will appear here automatically.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -1,0 +1,140 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Search as SearchIcon, Filter } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Evidence } from "@shared/schema";
+
+function matchesQuery(evidence: Evidence, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  const haystack = [
+    evidence.filename,
+    evidence.description ?? "",
+    evidence.artifactId ?? "",
+    evidence.evidenceTier ?? "",
+    evidence.status ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(normalizedQuery);
+}
+
+export default function Search() {
+  const [query, setQuery] = useState("");
+  const { data, isLoading, error } = useQuery<Evidence[]>({
+    queryKey: ["/api/evidence"],
+  });
+
+  const evidenceList = Array.isArray(data) ? data : [];
+  const results = useMemo(() => {
+    if (!query.trim()) {
+      return evidenceList.slice(0, 6);
+    }
+
+    return evidenceList.filter((item) => matchesQuery(item, query)).slice(0, 12);
+  }, [evidenceList, query]);
+
+  return (
+    <section className="py-24 bg-slate-950 min-h-screen">
+      <div className="container mx-auto px-8">
+        <div className="flex items-center justify-between mb-12">
+          <div>
+            <h2 className="text-4xl font-bold text-slate-50 mb-3">Evidence Search</h2>
+            <p className="text-slate-400 max-w-2xl">
+              Instantly surface ledger-qualified evidence with tier, status, and custody context pulled directly from ChittyChain.
+            </p>
+          </div>
+          <Button variant="outline" className="border-slate-700 text-slate-300 hover:bg-slate-800">
+            <Filter className="w-4 h-4 mr-2" />
+            Advanced Filters
+          </Button>
+        </div>
+
+        <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-8 shadow-xl">
+          <div className="relative mb-8">
+            <SearchIcon className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500 w-5 h-5" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search by artifact ID, filename, or description..."
+              className="pl-12 pr-4 py-6 text-lg bg-slate-950/70 border-slate-800 text-slate-100"
+            />
+          </div>
+
+          {error && (
+            <Card className="bg-red-900/20 border-red-500/40 text-red-200 mb-6">
+              <CardHeader>
+                <CardTitle className="text-red-100 text-lg">Search unavailable</CardTitle>
+                <CardDescription className="text-red-200">
+                  We could not load evidence data. Please refresh the page or try again later.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {isLoading &&
+              Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="h-32 rounded-xl bg-slate-800/60 animate-pulse" />
+              ))}
+
+            {!isLoading && results.length === 0 && (
+              <Card className="bg-slate-900/70 border-slate-800">
+                <CardHeader>
+                  <CardTitle className="text-slate-100 text-xl">No evidence found</CardTitle>
+                  <CardDescription className="text-slate-400">
+                    Try refining your search terms or removing filters to broaden the results.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            )}
+
+            {results.map((item) => (
+              <Card key={item.id} className="bg-slate-900/70 border-slate-800 hover:border-emerald-400/50 transition-colors">
+                <CardHeader className="pb-4">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <CardTitle className="text-slate-100 text-xl mb-1">{item.filename}</CardTitle>
+                      <CardDescription className="text-slate-400">
+                        {item.description ?? "No description provided"}
+                      </CardDescription>
+                    </div>
+                    <Badge
+                      className={`uppercase tracking-wide ${
+                        item.status === "MINTED"
+                          ? "bg-emerald-400/20 text-emerald-300 border-emerald-400/40"
+                          : "bg-slate-800 text-slate-300 border-slate-700"
+                      }`}
+                    >
+                      {item.status ?? "Unknown"}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="text-sm text-slate-300 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-500">Artifact ID</span>
+                    <span className="font-mono text-slate-200">{item.artifactId}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-500">Evidence Tier</span>
+                    <span>{item.evidenceTier}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-500">Trust Score</span>
+                    <span>{item.trustScore}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,12 +39,16 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  app.use((err: any, req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
+    log(`${req.method} ${req.path} -> ${status} ${message}`, "error");
+    if (err?.stack) {
+      console.error(err.stack);
+    }
+
     res.status(status).json({ message });
-    throw err;
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- add routed Search and Chain experiences so navigation entries resolve to dedicated pages
- ensure hero metrics respect zero values by switching to nullish coalescing fallbacks
- update the server error handler to log failures without rethrowing and crashing the process

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_6907cec1a9c4832486e684f996f8ddde