### PR TITLE
feat(pentad): Pentad completion (F-039)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+---
+service_chittyid: "TBD-pending-canonical-mint"
+service_name: "chittyledger"
+canonical_uri: "chittycanon://core/services/chittyledger"
+pentad_version: "0.1.0"
+tier: 9
+last_reviewed: "2026-05-26"
+---
+
+# chittyledger — AGENTS
+
+Stub for Pentad completion (F-039). Real content TBD per template at chittycanon://gov/sops/020-service-authoring-pentad.
+
+Refs: F-039.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+---
+service_chittyid: "TBD-pending-canonical-mint"
+service_name: "chittyledger"
+canonical_uri: "chittycanon://core/services/chittyledger"
+pentad_version: "0.1.0"
+tier: 9
+last_reviewed: "2026-05-26"
+---
+
+# chittyledger — SECURITY
+
+Stub for Pentad completion (F-039). Real content TBD per template at chittycanon://gov/sops/020-service-authoring-pentad.
+
+Refs: F-039.


### PR DESCRIPTION
Closes part of F-039 (Pentad non-compliance) from 2026-05-26 ecosystem audit.

Adds missing Pentad documents per chittycanon GOVERNANCE.md mandate that Tier ≥ 1 services have CHARTER + CHITTY + CLAUDE + SECURITY + AGENTS (+THREAT_MODEL for Tier 0).

These are scaffolded stubs that satisfy the EXISTENCE requirement and reference templates at:
- chittycanon://gov/sops/020-service-authoring-pentad
- /Users/nb/Workspace/process-ops/state/ecosystem-discovery/pentad-templates/

Real per-service content authorship is welcome before merge.

Refs:
- F-039 — process-ops state/ecosystem-discovery/conflicts-register.md
- SOP-020 v0.2.0 (Service Authoring Pentad)
- Wave A in STATE.md resolution-wave plan

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>